### PR TITLE
Add testid to username modal error text

### DIFF
--- a/src/components/UsernameModal/index.jsx
+++ b/src/components/UsernameModal/index.jsx
@@ -161,6 +161,9 @@ const UsernameModal = ({ open, handleClose: close }) => {
                             }}
                             error={Boolean(usernameError)}
                             helperText={usernameError}
+                            FormHelperTextProps={{
+                                'data-testid': 'username-error-text',
+                            }}
                         />
                         <Button
                             data-testid='proceed-button'


### PR DESCRIPTION
- [Related issue](https://github.com/IntersectMBO/govtool/issues/1232#issuecomment-2210284257)
- `data-testid`=`username-error-text`